### PR TITLE
[FIX] - Sandwich game buttons

### DIFF
--- a/src/game/scenes/action/SandwichGameScene.ts
+++ b/src/game/scenes/action/SandwichGameScene.ts
@@ -293,6 +293,9 @@ export default class SandwichGameScene extends MinigameScene {
 
       btn.on('pointerdown', () => {
         if (this.isControlsEnabled) {
+          if (btn.texture.key.includes('on')) {
+            this.animateGame()
+          }
           if (btn === this.leftBtn) {
             this.leftBtn.setTexture('btn_left_off')
             this.rightBtn!.setTexture('btn_right_on')
@@ -300,7 +303,6 @@ export default class SandwichGameScene extends MinigameScene {
             this.leftBtn!.setTexture('btn_left_on')
             this.rightBtn!.setTexture('btn_right_off')
           }
-          this.animateGame()
         }
       })
     })


### PR DESCRIPTION
## 📋 Spécifications techniques
<!-- Globalement, décris en gros ce que t'as fait dans cette PR dans une liste à puce claire et concise -->
Correction du bug lorsque l'utilisateur pouvait taper sur un bouton normalement désactivé dans le jeu du Sandwich