### PR TITLE
[FEAT] - Haptic feedback

### DIFF
--- a/src/components/GameDebug.tsx
+++ b/src/components/GameDebug.tsx
@@ -3,6 +3,7 @@ import GameDebugStateList from './ui/debug/GameDebugStateList'
 import { FunctionComponent } from 'react'
 import GameDebugConfigPanel from './ui/debug/GameDebugConfigPanel'
 import { HideableProps } from '../utils/interfaces'
+import GameDebugSettingsPanel from './ui/debug/GameDebugSettingsPanel'
 
 const GameDebug: FunctionComponent<HideableProps> = props => {
   const { hide } = props
@@ -13,8 +14,9 @@ const GameDebug: FunctionComponent<HideableProps> = props => {
       className="game-debug game-ui"
     >
       <h1>Debug interface</h1>
-      <GameDebugConfigPanel title="Game config" x={10} y={180} />
+      <GameDebugConfigPanel title="Game config" x={10} y={220} />
       <GameDebugStateList title="Game state" x={10} y={10} />
+      <GameDebugSettingsPanel title="Game settings" x={10} y={220} />
     </div>
   )
 }

--- a/src/components/ui/BigButton.tsx
+++ b/src/components/ui/BigButton.tsx
@@ -35,6 +35,7 @@ const BigButton: FunctionComponent<Props> = props => {
   const { onClick } = props
 
   const onClickHandler: MouseEventHandler<HTMLButtonElement> = evt => {
+    gameManager.vibrate(30)
     if (gameManager.audio) {
       gameManager.audio.playSfx('explosion')
     }

--- a/src/components/ui/GameButton.tsx
+++ b/src/components/ui/GameButton.tsx
@@ -16,6 +16,7 @@ const GameButton: FunctionComponent<Props> = props => {
     if (gameManager.audio) {
       gameManager.audio.playSfx('explosion')
     }
+    gameManager.vibrate(30)
     if (onClick) {
       onClick(evt)
     }

--- a/src/components/ui/debug/GameDebugSettingsPanel.tsx
+++ b/src/components/ui/debug/GameDebugSettingsPanel.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+import { useCallback, ChangeEventHandler, FunctionComponent } from 'react'
+import { observer } from 'mobx-react-lite'
+import DebugContainer from './DebugContainer'
+import { PositionneableProps, TitledProps } from '../../../utils/interfaces'
+import gameStore from '../../../store/GameStore'
+import ValidatableInput from '../ValidatableInput'
+import Spacer from '../Spacer'
+
+const GameDebugSettingsPanel: FunctionComponent<
+  TitledProps & PositionneableProps
+> = props => {
+  const {
+    changeSettings,
+    settings: { volume, vibrations },
+  } = gameStore
+
+  const onChangeVibrationsInput = useCallback(
+    () => {
+      changeSettings({
+        vibrations: !vibrations,
+      })
+    },
+    [vibrations]
+  )
+
+  const handleOnValidateVolume = useCallback((value: string) => {
+    changeSettings({
+      volume: Number(value),
+    })
+  }, [])
+
+  const onChangeVolumeInput: ChangeEventHandler<HTMLInputElement> = evt => {
+    changeSettings({
+      volume: Number(evt.target.value),
+    })
+  }
+
+  return (
+    <>
+      <DebugContainer {...props}>
+        <label>
+          <span>Volume : </span>
+          <ValidatableInput
+            value={String(volume)}
+            onChange={onChangeVolumeInput}
+            onValidate={handleOnValidateVolume}
+            className="input"
+            type="number"
+            step="0.1"
+            max={1}
+            min={0}
+          />
+        </label>
+        <Spacer />
+        <label>
+          <input
+            type="checkbox"
+            className="checkbox"
+            checked={vibrations}
+            onChange={onChangeVibrationsInput}
+          />
+          <span>Vibrations?</span>
+        </label>
+      </DebugContainer>
+    </>
+  )
+}
+
+export default observer(GameDebugSettingsPanel)

--- a/src/components/ui/games/GamePauseButton.tsx
+++ b/src/components/ui/games/GamePauseButton.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, MouseEventHandler } from 'react'
 import styled from 'styled-components'
 import { green, lightGray, white } from '../../../utils/colors'
 import PauseIcon from '../icons/PauseIcon'
@@ -52,11 +52,16 @@ const GamePauseButton: FunctionComponent = () => {
   const { paused, canPause, showingGuideline } = gameStore
   const { togglePause } = gameManager
 
+  const onClick = () => {
+    gameManager.vibrate(30)
+    togglePause()
+  }
+
   return (
     <Button
       disabled={showingGuideline || !canPause}
       paused={paused}
-      onClick={togglePause}
+      onClick={onClick}
     >
       <PauseIcon />
     </Button>

--- a/src/game/manager/AudioManager.ts
+++ b/src/game/manager/AudioManager.ts
@@ -19,10 +19,15 @@ export default class AudioManager {
     return this.sound.mute
   }
 
+  set volume(value: number) {
+    this.sound.volume = value
+  }
+
   constructor(private gm: GameManager) {
     this.sound = gm.game.sound
     this.previousDetune = this.sound.detune
     this.sound.pauseOnBlur = true
+    this.sound.volume = gameStore.settings.volume
   }
 
   set detuneBg(value: number) {

--- a/src/game/manager/GameManager.ts
+++ b/src/game/manager/GameManager.ts
@@ -51,6 +51,12 @@ export class GameManager {
   }
 
   public vibrate = (pattern: number | number[] = 10): boolean => {
+    const {
+      settings: { vibrations },
+    } = gameStore
+    if (!vibrations) {
+      return false
+    }
     return window.navigator.vibrate(pattern)
   }
 

--- a/src/game/manager/GameManager.ts
+++ b/src/game/manager/GameManager.ts
@@ -50,6 +50,10 @@ export class GameManager {
     })
   }
 
+  public vibrate = (pattern: number | number[] = 10): boolean => {
+    return window.navigator.vibrate(pattern)
+  }
+
   public startGame = (): void => {
     ;(this.game.scene.getScene(scenesKeys.Boot) as BootScene).startGame()
   }

--- a/src/game/objects/Spam.ts
+++ b/src/game/objects/Spam.ts
@@ -3,6 +3,7 @@ import gameStore from '../../store/GameStore'
 import { Emitter } from '../manager/GameManager'
 import { GameEvents } from '../../utils/enums'
 import { randomRange } from '../../utils/functions'
+import gameManager from '../manager/GameManager'
 
 export default class Spam extends Phaser.GameObjects.Container {
   private readonly spamContent?: Phaser.GameObjects.Sprite
@@ -64,6 +65,7 @@ export default class Spam extends Phaser.GameObjects.Container {
     sprite.anims.play(this.texture)
     sprite.setInteractive()
     sprite.on('pointerdown', () => {
+      gameManager.vibrate()
       Emitter.emit(GameEvents.SpamClicked, this)
     })
 
@@ -78,6 +80,7 @@ export default class Spam extends Phaser.GameObjects.Container {
       .setScale(1 / gameStore.ratioResolution)
     close.setInteractive()
     close.on('pointerdown', () => {
+      gameManager.vibrate()
       Emitter.emit(GameEvents.SpamDestroyed, this)
       this.destroy(true)
     })

--- a/src/game/objects/password-game/KeyboardPasswordButton.ts
+++ b/src/game/objects/password-game/KeyboardPasswordButton.ts
@@ -3,6 +3,7 @@ import gameStore from '../../../store/GameStore'
 import { Emitter } from '../../manager/GameManager'
 import { GameEvents } from '../../../utils/enums'
 import { Omit } from '../../../utils/types'
+import gameManager from '../../manager/GameManager'
 
 export type Code = '◻' | '▲' | '|||' | '☰' | 'O' | 'U'
 
@@ -54,6 +55,7 @@ export default class KeyboardPasswordButton extends Phaser.GameObjects.Sprite {
         this.setTexture(`${texture}`)
       })
       this.on('pointerdown', () => {
+        gameManager.vibrate()
         Emitter.emit(GameEvents.KeyboardPasswordButtonClicked, this.code)
       })
     }

--- a/src/game/scenes/action/ElevatorGameScene.ts
+++ b/src/game/scenes/action/ElevatorGameScene.ts
@@ -219,6 +219,7 @@ export default class ElevatorGameScene extends MinigameScene {
 
     const onPointerDown = () => {
       this.destroyActionIndicator()
+      gameManager.vibrate()
       this.hitCaseCallElevator++
       if (this.hitCaseCallElevator === this.nbrHitCaseCall) {
         this.currentFrame++

--- a/src/game/scenes/action/SandwichGameScene.ts
+++ b/src/game/scenes/action/SandwichGameScene.ts
@@ -293,6 +293,7 @@ export default class SandwichGameScene extends MinigameScene {
         if (this.isControlsEnabled) {
           if (btn.texture.key.includes('on')) {
             this.animateGame()
+            gameManager.vibrate()
           }
           if (btn === this.leftBtn) {
             this.leftBtn.setTexture('btn_left_off')

--- a/src/game/scenes/action/TrafficGameScene.ts
+++ b/src/game/scenes/action/TrafficGameScene.ts
@@ -154,6 +154,7 @@ export default class TraficGameScene extends MinigameScene {
       controlsContainer.x - (controlsContainer.width * 15) / 2
 
     this.horn.on('pointerdown', () => {
+      gameManager.vibrate()
       this.destroyActionIndicator()
       this.horn!.setTexture('traffic_horn_on')
       gameManager.audio.playUniqueSfx(HORN_SOUND, {

--- a/src/store/GameStore.ts
+++ b/src/store/GameStore.ts
@@ -15,6 +15,8 @@ interface TokiStatus {
   hasJustHeart: boolean
 }
 
+const LS_GAME_SETTINGS = 'settings'
+
 const MINIGAME_DURATION = 500
 const REMAINING_PAUSE = 10
 
@@ -41,7 +43,7 @@ class GameStore {
     current: 0,
   }
   @observable public paused: boolean = false
-  @observable public settings: GameSettings = { volume: 1 }
+  @observable public settings: GameSettings = { volume: 1, vibrations: true }
   @observable public config: HFLGameConfig = {
     dev: process.env.NODE_ENV === 'development',
     suspended: false,
@@ -57,6 +59,20 @@ class GameStore {
   public uiKey: string = new Phaser.Math.RandomDataGenerator().uuid()
 
   constructor(private client: HFLApiClient) {
+    if (!window.localStorage.getItem(LS_GAME_SETTINGS)) {
+      window.localStorage.setItem(
+        LS_GAME_SETTINGS,
+        JSON.stringify(this.settings)
+      )
+    }
+    this.settings = JSON.parse(window.localStorage.getItem(LS_GAME_SETTINGS)!)
+    reaction(
+      () => this.settings,
+      settings => {
+        window.localStorage.setItem(LS_GAME_SETTINGS, JSON.stringify(settings))
+        gameManager.audio.volume = settings.volume
+      }
+    )
     reaction(
       () => this.difficulty,
       difficulty => {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -17,6 +17,7 @@ export interface KeyboardShortcut {
 
 export interface GameSettings {
   volume: number
+  vibrations: boolean
 }
 
 export interface HideableProps {


### PR DESCRIPTION
## 📋 Spécifications techniques
<!-- Globalement, décris en gros ce que t'as fait dans cette PR dans une liste à puce claire et concise -->
Ajout des vibrations lors d'interactions utilisateur. Possibilité de les activer / désactiver.
Le volume est désormais modifiable et influe sur tout les sons du jeu.
Les settings du jeu sont sauvegardés de façon persistante dans le **localStorage**. Actuellement, seul l'interface de débug permet de modifier ces valeurs, mais un menu dédié à cela sera ajouté au jeu.

- [x] Ajout d'un nouveau panel de debug : `GameDebugSettingsPanel`
	- Permet de modifier la configuration du jeu : le volume et les vibrations
- [x] Ajout d'une nouvelle `reaction` mobx dans le `GameStore` permettant de persister les paramètres du jeu dans le **localStorage** lorsqu'ils sont modifiés