### PR TITLE
[FEAT] - Randomize minigame's background color

### DIFF
--- a/src/game/scenes/MinigameScene.ts
+++ b/src/game/scenes/MinigameScene.ts
@@ -4,14 +4,20 @@ import { GameEvents } from '../../utils/enums'
 import { MinigameGuideline } from '../../utils/interfaces'
 import gameStore from '../../store/GameStore'
 import minigameManager from '../manager/MinigameManager'
+import { List } from '../../utils/extensions'
+import { green } from '../../utils/colors'
 
 export default abstract class MinigameScene extends BaseScene {
   public abstract guideline: MinigameGuideline
+  protected availableBackgroundColors: List<string> = new List([green])
   protected hasActionIndicators = false
   protected actionIndicator?: Phaser.GameObjects.Sprite
 
   public create(): void {
     super.create()
+    gameStore.changeConfig({
+      backgroundColor: this.availableBackgroundColors.random(),
+    })
     gameStore.regenerateUiKey()
     if (this.hasActionIndicators) {
       gameManager.suspendMinigame()

--- a/src/game/scenes/PostMinigameScene.ts
+++ b/src/game/scenes/PostMinigameScene.ts
@@ -3,6 +3,7 @@ import BaseScene from './BaseScene'
 import { gameWait } from '../../utils/functions'
 import gameManager from '../manager/GameManager'
 import gameStore from '../../store/GameStore'
+import { green } from '../../utils/colors'
 
 const SOUND_LOST = 'hit'
 const SOUND_WIN = 'success'
@@ -17,6 +18,9 @@ export default class PostMinigameScene extends BaseScene {
 
   public create = async () => {
     super.create()
+    gameStore.changeConfig({
+      backgroundColor: green,
+    })
     this.createFillerGraphics()
     if (gameManager.audio.ambientPlaying) {
       gameManager.audio.stopAmbientMusic()

--- a/src/game/scenes/action/ElevatorGameScene.ts
+++ b/src/game/scenes/action/ElevatorGameScene.ts
@@ -4,6 +4,15 @@ import { scenesKeys } from '../../../utils/constants'
 import gameStore from '../../../store/GameStore'
 import { gameWait } from '../../../utils/functions'
 import { MinigameGuideline } from '../../../utils/interfaces'
+import { List } from '../../../utils/extensions'
+import {
+  blue,
+  darkGray,
+  green,
+  lightBlue,
+  lightGray,
+  mediumGray,
+} from '../../../utils/colors'
 
 const CLICK_SOUND = 'click'
 const ANGRY_SOUND = 'angry'
@@ -16,6 +25,14 @@ export default class ElevatorGameScene extends MinigameScene {
     title: 'Call !',
     subtitle: 'the elevator',
   }
+  public availableBackgroundColors = new List<string>([
+    lightBlue,
+    blue,
+    darkGray,
+    mediumGray,
+    lightGray,
+    green,
+  ])
 
   protected hasActionIndicators = true
 

--- a/src/game/scenes/action/PasswordGameScene.ts
+++ b/src/game/scenes/action/PasswordGameScene.ts
@@ -10,6 +10,8 @@ import { GameEvents } from '../../../utils/enums'
 import ComputerPasswordScreen from '../../objects/password-game/ComputerPasswordScreen'
 import gameStore from '../../../store/GameStore'
 import { MinigameGuideline } from '../../../utils/interfaces'
+import { List } from '../../../utils/extensions'
+import { green, lightBlue, lightRed, pink } from '../../../utils/colors'
 
 const PASSWORD_DISPLAY_TIME = 3000
 const PAW_DISPLAY_TIME = 180
@@ -27,6 +29,13 @@ export default class PasswordGameScene extends MinigameScene {
     title: 'Memorise !',
     subtitle: 'to enter password',
   }
+  public availableBackgroundColors = new List<string>([
+    green,
+    pink,
+    lightRed,
+    lightBlue,
+  ])
+
   public password: Code[] = []
   public typedPassword: Code[] = []
   private keyboard?: KeyboardContainer

--- a/src/game/scenes/action/SandwichGameScene.ts
+++ b/src/game/scenes/action/SandwichGameScene.ts
@@ -5,6 +5,8 @@ import MinigameScene from '../MinigameScene'
 import gameStore from '../../../store/GameStore'
 import { gameWait, randomRange } from '../../../utils/functions'
 import { MinigameGuideline } from '../../../utils/interfaces'
+import { List } from '../../../utils/extensions'
+import { green, yellow } from '../../../utils/colors'
 
 const SOUND_WALK = 'beep'
 const SOUND_GET_SANDWICH = 'tada'
@@ -14,6 +16,8 @@ export default class SandwichGameScene extends MinigameScene {
     title: 'Run !',
     subtitle: 'to get your food',
   }
+  public availableBackgroundColors = new List<string>([green, yellow])
+
   private skies?: Phaser.GameObjects.Sprite[] = []
   private buildings?: Phaser.GameObjects.Sprite[] = []
   private landscapes?: Phaser.GameObjects.Sprite[] = []

--- a/src/game/scenes/action/SpamGameScene.ts
+++ b/src/game/scenes/action/SpamGameScene.ts
@@ -7,6 +7,17 @@ import gameManager, { Emitter } from '../../manager/GameManager'
 import MinigameScene from '../MinigameScene'
 import { MinigameGuideline } from '../../../utils/interfaces'
 import gameStore from '../../../store/GameStore'
+import {
+  blue,
+  green,
+  lightBlue,
+  lightGray,
+  lightRed,
+  mediumGray,
+  orange,
+  pink,
+  yellow,
+} from '../../../utils/colors'
 
 const SOUND_SPAM_DESTROYED = 'explosion'
 const SOUND_CLOSE_CLICK = 'beep'
@@ -16,6 +27,18 @@ export default class SpamGameScene extends MinigameScene {
     title: 'Click !',
     subtitle: 'to close the spams',
   }
+  public availableBackgroundColors = new List<string>([
+    green,
+    lightGray,
+    mediumGray,
+    yellow,
+    pink,
+    blue,
+    orange,
+    lightRed,
+    lightBlue,
+  ])
+
   public spams: List<Spam> = new List<Spam>()
   constructor() {
     super({

--- a/src/game/scenes/action/SubwayGameScene.ts
+++ b/src/game/scenes/action/SubwayGameScene.ts
@@ -3,9 +3,15 @@ import { scenesKeys } from '../../../utils/constants'
 import { MinigameGuideline } from '../../../utils/interfaces'
 import gameStore from '../../../store/GameStore'
 import { gameWait, randomRange } from '../../../utils/functions'
-import Wagon from '../../objects/subway-game/Wagon'
 import gameManager from '../../manager/GameManager'
-import { lightBlue } from '../../../utils/colors'
+import { List } from '../../../utils/extensions'
+import {
+  blue,
+  darkGray,
+  lightBlue,
+  lightGray,
+  mediumGray,
+} from '../../../utils/colors'
 
 const SOUND_ERROR = 'error'
 const SOUND_HIT = 'hit'
@@ -16,6 +22,13 @@ export default class SubwayGameScene extends MinigameScene {
     title: 'Slide !',
     subtitle: 'to enter the train',
   }
+  public availableBackgroundColors = new List<string>([
+    lightBlue,
+    blue,
+    darkGray,
+    mediumGray,
+    lightGray,
+  ])
 
   private windowHeight?: number
   private windowWidth?: number
@@ -57,40 +70,10 @@ export default class SubwayGameScene extends MinigameScene {
     })
   }
 
-  private resetVariables(): void {
-    this.windowHeight = 0
-    this.windowWidth = 0
-    this.normalizedYOffset = 0
-    this.lineContainers = []
-    this.spriteLine = []
-    this.emptySlabs = []
-    this.toki = undefined
-    this.indexCurrentRow = 0
-    this.indexNextRow = 1
-    this.allowTokiToRun = true
-    this.isOverlapping = false
-    this.currentRow = undefined
-    this.nextRow = undefined
-    this.lastLineReached = false
-    this.train = []
-    this.firstTrain = undefined
-    this.doorsActiveTrain = undefined
-    this.activeTrainContainer = undefined
-    this.containers = []
-    this.nextEmptySlab = undefined
-    this.currentEmptySlab = undefined
-    this.goalZone = undefined
-    this.gapX = 0
-    this.gapY = 0
-    this.numberHiddenCharacters = 0
-    this.allowTokiToRun = true
-  }
-
   public create() {
     super.create()
     gameManager.suspendMinigame()
     this.resetVariables()
-    gameManager.changeBackgroundColor(lightBlue)
     this.windowHeight = Number(this.game.config.height)
     this.windowWidth = Number(this.game.config.width)
     this.normalizedYOffset =
@@ -104,7 +87,9 @@ export default class SubwayGameScene extends MinigameScene {
     let yPointer = 0
 
     this.numberHiddenCharacters = Math.floor(this.windowWidth / 90)
-    if (this.numberHiddenCharacters % 2 === 1) this.numberHiddenCharacters -= 1
+    if (this.numberHiddenCharacters % 2 === 1) {
+      this.numberHiddenCharacters -= 1
+    }
     const xCounter = this.numberHiddenCharacters * 3
     this.slabWidth = 55
     this.gapX =
@@ -241,10 +226,39 @@ export default class SubwayGameScene extends MinigameScene {
     }
 
     this.isOverlapping = this.physics.world.overlap(
-      //@ts-ignore
+      // @ts-ignore
       this.nextEmptySlab!,
       this.goalZone!
     )
+  }
+
+  private resetVariables(): void {
+    this.windowHeight = 0
+    this.windowWidth = 0
+    this.normalizedYOffset = 0
+    this.lineContainers = []
+    this.spriteLine = []
+    this.emptySlabs = []
+    this.toki = undefined
+    this.indexCurrentRow = 0
+    this.indexNextRow = 1
+    this.allowTokiToRun = true
+    this.isOverlapping = false
+    this.currentRow = undefined
+    this.nextRow = undefined
+    this.lastLineReached = false
+    this.train = []
+    this.firstTrain = undefined
+    this.doorsActiveTrain = undefined
+    this.activeTrainContainer = undefined
+    this.containers = []
+    this.nextEmptySlab = undefined
+    this.currentEmptySlab = undefined
+    this.goalZone = undefined
+    this.gapX = 0
+    this.gapY = 0
+    this.numberHiddenCharacters = 0
+    this.allowTokiToRun = true
   }
 
   private generateEmptySlabPosition(): integer {

--- a/src/store/GameStore.ts
+++ b/src/store/GameStore.ts
@@ -5,6 +5,7 @@ import { HFLGameConfig } from '../utils/game'
 import gameManager from '../game/manager/GameManager'
 import { green } from '../utils/colors'
 import HFLApiClient from '../client/HFLApiClient'
+import { gameBackgroundColorToCss } from '../utils/functions'
 
 interface TokiStatus {
   hasStress: boolean
@@ -163,6 +164,12 @@ class GameStore {
   @action public changeConfig = (newConfig: Partial<HFLGameConfig>): void => {
     this.config = { ...this.config, ...newConfig }
     if (newConfig.backgroundColor) {
+      document
+        .querySelector('meta[name="theme-color"]')!
+        .setAttribute(
+          'content',
+          gameBackgroundColorToCss(newConfig.backgroundColor)
+        )
       gameManager.changeBackgroundColor(this.config.backgroundColor)
     }
   }


### PR DESCRIPTION
## 📋 Spécifications techniques
<!-- Globalement, décris en gros ce que t'as fait dans cette PR dans une liste à puce claire et concise -->
Ajout de la possibilité de changer de façon aléatoire le fond des mini-jeux.
- [x] Ajout d'un champs `availableBackgroundColors` pour les scènes de type `MinigameScene`