### PR TITLE
Fix/deathscreen

### DIFF
--- a/src/components/ui/DeathscreenUI.tsx
+++ b/src/components/ui/DeathscreenUI.tsx
@@ -14,20 +14,21 @@ const Div = styled.div`
   bottom: 0;
 `
 
-const ContainerMessage = styled.div`
+const ContainerMessage = styled.div<{ position: string; paddingTop: integer }>`
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  display: flex;
-  align-items: center;
   text-align: center;
+  display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: ${props => props.position};
   font-size: 26px;
   background-color: rgba(0, 0, 0, 0.5);
   line-height: 1.5em;
-  padding: 50px 40px;
+  padding: ${props => props.paddingTop}px 40px 0px 40px;
   p {
     max-width: 1280px;
   }
@@ -63,12 +64,20 @@ const DeathscreenUI: FunctionComponent = () => {
   const [percent, setPercent] = useState(0)
   const [deathTime, setDeathTime] = useState('15.02.19')
   const [fontColor, setFontColor] = useState(lightGray)
+  const [containerMessagePosition, setContainerMessagePosition] = useState(
+    'normal'
+  )
+  const [containerMessagePaddingTop, setcontainerMessagePaddingTop] = useState(
+    50
+  )
 
   useEffect(() => {
     Emitter.on(GameEvents.DeathscreenFirstSceneDestroyed, args => {
       setPercent(args.percent)
       setMessage(<p>{args.text}</p>)
       setShowButton(true)
+      setContainerMessagePosition('center')
+      setcontainerMessagePaddingTop(0)
     })
 
     Emitter.on(GameEvents.DeathscreenThunderOn, () => {
@@ -99,7 +108,10 @@ const DeathscreenUI: FunctionComponent = () => {
   return (
     <Div className="deathscreen-ui">
       <DeathTime fontColor={fontColor}>{deathTime}</DeathTime>
-      <ContainerMessage>
+      <ContainerMessage
+        position={containerMessagePosition}
+        paddingTop={containerMessagePaddingTop}
+      >
         {showButton && (
           <PercentData>
             <CountUp start={0} end={percent} />

--- a/src/components/ui/DeathscreenUI.tsx
+++ b/src/components/ui/DeathscreenUI.tsx
@@ -95,7 +95,7 @@ const DeathscreenUI: FunctionComponent = () => {
 
     const newDate = new Date()
     let day = newDate.getDate().toString()
-    let month = newDate.getMonth().toString()
+    let month = (newDate.getMonth() + 1).toString()
     let year = newDate.getFullYear().toString()
     year = year.slice(-2)
 

--- a/src/components/ui/DeathscreenUI.tsx
+++ b/src/components/ui/DeathscreenUI.tsx
@@ -73,6 +73,7 @@ const DeathscreenUI: FunctionComponent = () => {
 
   useEffect(() => {
     Emitter.on(GameEvents.DeathscreenFirstSceneDestroyed, args => {
+      setFontColor('transparent')
       setPercent(args.percent)
       setMessage(<p>{args.text}</p>)
       setShowButton(true)
@@ -80,8 +81,12 @@ const DeathscreenUI: FunctionComponent = () => {
       setcontainerMessagePaddingTop(0)
     })
 
-    Emitter.on(GameEvents.DeathscreenThunderOn, () => {
-      setFontColor(white)
+    Emitter.on(GameEvents.DeathscreenThunderOn, args => {
+      if (args === false) {
+        setFontColor(white)
+      } else {
+        setFontColor('transparent')
+      }
     })
 
     Emitter.on(GameEvents.DeathscreenThunderOff, () => {

--- a/src/components/ui/DeathscreenUI.tsx
+++ b/src/components/ui/DeathscreenUI.tsx
@@ -22,13 +22,12 @@ const ContainerMessage = styled.div`
   bottom: 0;
   display: flex;
   align-items: center;
-  justify-content: center;
   text-align: center;
   flex-direction: column;
   font-size: 26px;
   background-color: rgba(0, 0, 0, 0.5);
   line-height: 1.5em;
-  padding: 0 40px;
+  padding: 50px 40px;
   p {
     max-width: 1280px;
   }

--- a/src/game/scenes/DeathscreenScene.ts
+++ b/src/game/scenes/DeathscreenScene.ts
@@ -44,7 +44,9 @@ export default class DeathscreenScene extends BaseScene {
         gameManager.audio.playSfx(SOUND_THUNDER, { volume: 0.2, delay: 0.3 })
 
         await gameWait(this.time, 300)
-        Emitter.emit(GameEvents.DeathscreenThunderOff)
+        if (!this.firstPartDestroyed) {
+          Emitter.emit(GameEvents.DeathscreenThunderOff)
+        }
       }
     })
 
@@ -113,7 +115,9 @@ export default class DeathscreenScene extends BaseScene {
 
     await gameWait(this.time, delayLightning)
 
-    Emitter.emit(GameEvents.DeathscreenThunderOn, this.firstPartDestroyed)
+    if (!this.firstPartDestroyed) {
+      Emitter.emit(GameEvents.DeathscreenThunderOn, this.firstPartDestroyed)
+    }
   }
 
   private initSecondPart(): void {

--- a/src/game/scenes/DeathscreenScene.ts
+++ b/src/game/scenes/DeathscreenScene.ts
@@ -113,7 +113,7 @@ export default class DeathscreenScene extends BaseScene {
 
     await gameWait(this.time, delayLightning)
 
-    Emitter.emit(GameEvents.DeathscreenThunderOn)
+    Emitter.emit(GameEvents.DeathscreenThunderOn, this.firstPartDestroyed)
   }
 
   private initSecondPart(): void {


### PR DESCRIPTION
## 📋 Spécifications techniques
- [x] La date sur la tombe de Toki n'est plus caché par le message au 1er plan
- [x] Le message est replacé au centre pour la 2ème partie du DeathScreen
- [x] Correction d'un bug qui montrait le date sur la tombe sur la 2ème partie
- [x] Amélioration de l'envoie des événements pour déclencher le tonnerre. On condition restreint l'envoi de l'événement pour éviter qu'il soit émit pendant la 2ème partie.
- [x] Correction du numéro du mois affiché dans la date de mort de Toki (la méthode getMonth() commence à 0 pour janvier)
