### PR TITLE
[FIX] Subway game

### DIFF
--- a/public/static/assets/sprites/animations.json
+++ b/public/static/assets/sprites/animations.json
@@ -480,7 +480,7 @@
         "end": 8
       },
       "showOnStart": true,
-      "repeat": 0,
+      "repeat": -1,
       "frameRate": 30
     },
     {

--- a/src/game/scenes/action/SubwayGameScene.ts
+++ b/src/game/scenes/action/SubwayGameScene.ts
@@ -209,20 +209,6 @@ export default class SubwayGameScene extends MinigameScene {
   }
 
   public update(time: number, delta: number): void {
-    let threshold =
-      -(this.gapY + this.slabWidth) * this.indexCurrentRow + this.slabWidth / 2
-    let xIncrement = 0
-
-    if (this.lastLineReached) {
-      threshold = -(this.windowHeight! * (6.6 / 10) - (this.gapY + 5))
-      xIncrement = this.gapX / 19.3
-    }
-
-    if (this.allowTokiToRun && this.toki!.y > threshold) {
-      this.toki!.y -= 5
-      this.toki!.x -= xIncrement
-    }
-
     this.isOverlapping = this.physics.world.overlap(
       // @ts-ignore
       this.nextEmptySlab!,
@@ -304,7 +290,6 @@ export default class SubwayGameScene extends MinigameScene {
       this.lineContainers[this.indexNextRow].on(
         'drag',
         (pointer: any, dragX: number, dragY: number) => {
-          console.log(dragX)
           if (this.isTweenFirstLineEnable) {
             if (this.tweenLine) {
               this.tweenLine.stop()
@@ -367,6 +352,25 @@ export default class SubwayGameScene extends MinigameScene {
     gameManager.suspendMinigame()
     await gameWait(this.time, 500)
     this.lastLineReached = true
+
+    this.tweens.add({
+      targets: this.toki,
+      x: {
+        value: `-=${this.gapX / 1.7 + this.slabWidth / 2}`,
+        duration: 100,
+        ease: 'Cubic.easeOut',
+      },
+      y: {
+        value: `-=${Number(this.windowHeight) -
+          this.lineContainers![0].y +
+          this.slabWidth -
+          2}`,
+        duration: 300,
+        ease: 'Cubic.easeOut',
+      },
+      repeat: 0,
+    })
+
     const tokiWinAnimation = this.toki!.anims.play(
       'subwayTokiWinAnimation',
       true
@@ -412,6 +416,16 @@ export default class SubwayGameScene extends MinigameScene {
   }
 
   private triggerRunAnimation(): void {
+    this.tweens.add({
+      targets: this.toki,
+      y: {
+        value: `-=${this.gapY + this.slabWidth}`,
+        duration: 500,
+        ease: 'Cubic.easeOut',
+      },
+      repeat: 0,
+    })
+
     const animation = this.toki!.anims.play('subwayTokiRunAnimation', true)
 
     animation.on('animationcomplete', () => {
@@ -610,7 +624,6 @@ export default class SubwayGameScene extends MinigameScene {
         },
         repeat: -1,
         yoyo: true,
-        onComplete: () => {},
       })
     }
   }

--- a/src/game/scenes/action/SubwayGameScene.ts
+++ b/src/game/scenes/action/SubwayGameScene.ts
@@ -215,7 +215,7 @@ export default class SubwayGameScene extends MinigameScene {
 
     if (this.lastLineReached) {
       threshold = -(this.windowHeight! * (6.6 / 10) - (this.gapY + 5))
-      xIncrement = this.gapX / 19.4
+      xIncrement = this.gapX / 19.3
     }
 
     if (this.allowTokiToRun && this.toki!.y > threshold) {
@@ -379,7 +379,7 @@ export default class SubwayGameScene extends MinigameScene {
     tokiWinAnimation.on('animationcomplete', () => {
       this.allowTokiToRun = false
       this.toki!.x =
-        this.activeTrainContainer!.width / gameStore.ratioResolution / 2
+        this.activeTrainContainer!.width / gameStore.ratioResolution / 2 - 10
       this.toki!.y = -25
       this.toki!.setOrigin(0.5, 1)
       this.activeTrainContainer!.addAt(this.toki!, 1)

--- a/src/game/scenes/action/SubwayGameScene.ts
+++ b/src/game/scenes/action/SubwayGameScene.ts
@@ -357,8 +357,8 @@ export default class SubwayGameScene extends MinigameScene {
       targets: this.toki,
       x: {
         value: `-=${this.gapX / 1.7 + this.slabWidth / 2}`,
-        duration: 100,
-        ease: 'Cubic.easeOut',
+        duration: 300,
+        ease: 'Cubic.ease',
       },
       y: {
         value: `-=${Number(this.windowHeight) -
@@ -366,9 +366,8 @@ export default class SubwayGameScene extends MinigameScene {
           this.slabWidth -
           2}`,
         duration: 300,
-        ease: 'Cubic.easeOut',
+        ease: 'Cubic.ease',
       },
-      repeat: 0,
     })
 
     const tokiWinAnimation = this.toki!.anims.play(
@@ -416,22 +415,20 @@ export default class SubwayGameScene extends MinigameScene {
   }
 
   private triggerRunAnimation(): void {
+    this.toki!.anims.play('subwayTokiRunAnimation', true)
+
     this.tweens.add({
       targets: this.toki,
       y: {
         value: `-=${this.gapY + this.slabWidth}`,
-        duration: 500,
-        ease: 'Cubic.easeOut',
+        duration: 300,
+        ease: 'Cubic.ease',
       },
-      repeat: 0,
-    })
-
-    const animation = this.toki!.anims.play('subwayTokiRunAnimation', true)
-
-    animation.on('animationcomplete', () => {
-      if (!this.lastLineReached) {
-        this.toki!.anims.play('subwayTokiTimeAnimation', true)
-      }
+      onComplete: () => {
+        if (!this.lastLineReached) {
+          this.toki!.anims.play('subwayTokiTimeAnimation', true)
+        }
+      },
     })
   }
 

--- a/src/game/scenes/action/SubwayGameScene.ts
+++ b/src/game/scenes/action/SubwayGameScene.ts
@@ -318,9 +318,13 @@ export default class SubwayGameScene extends MinigameScene {
           this.triggerRunAnimation()
           this.updateActiveRows()
 
-          const translateValue =
+          let translateValue =
             this.currentEmptySlab!.x -
             (Math.abs(this.currentRow!.x) + this.goalZone!.x)
+
+          if (this.currentEmptySlab!.x + this.gapX === this.goalZone!.x) {
+            translateValue = 0
+          }
 
           this.tweens.add({
             targets: this.currentRow,

--- a/src/game/scenes/action/SubwayGameScene.ts
+++ b/src/game/scenes/action/SubwayGameScene.ts
@@ -116,7 +116,7 @@ export default class SubwayGameScene extends MinigameScene {
         const slab = this.add
           .sprite(
             xPointer * (this.slabWidth + this.gapX),
-            this.slabWidth / 2,
+            this.slabWidth / 1.5,
             slabTextureKey
           )
           .setOrigin(0, 1)


### PR DESCRIPTION
## 📋 Spécifications techniques

- [x] Refacto du sytème pour bouger Toki sur chaque ligne. On utilise maintenant les tweens de Phaser. Cela nous permet d'avoir un meilleur contrôle sur les valeurs, surtout pour le responsive.
Grace à cela, on peut maintenant changer l'animation de Toki lorsqu'il a fini son mouvement. Autrement dit, nous ne somme plus dépendant de la fin du spritesheet.
Maintenant, le changement d'animation est déclenché lors du callback `onComplete` du Tween de Phaser (auparavant, nous utilisions le callback `animationcomplete` )

- [x] Correction d'un bug qui corrigeait mal la position de la dalle vide quand on relâchait le click. 

- [x] Ajustement de la place de Toki dans le train

- [x] Ajustement de la place de Toki sur les dalles
